### PR TITLE
Updating env for mr1l0 typhos

### DIFF
--- a/launcher.sh
+++ b/launcher.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Uncomment and set to the latest version to freeze dependency
-export PCDS_CONDA_VER=5.8.4
+export PCDS_CONDA_VER=5.9.0
 source /cds/group/pcds/pyps/conda/pcds_conda
 
 launcher="$(realpath $0)"


### PR DESCRIPTION
The advanced button for mr1l0 which is supposed to open the typhos screen doesn't work with the current pcds_conda version but does work on 5.9
